### PR TITLE
New feature: Monitoring resources

### DIFF
--- a/app/endpoints.go
+++ b/app/endpoints.go
@@ -17,6 +17,10 @@ func (ep *endpoints) GetPolicy(c *gin.Context) {
 	c.JSON(200, policy.RecreatePlan(ep.wp.policy))
 }
 
+func (ep *endpoints) GetResourceStatus(c *gin.Context) {
+	c.JSON(200, ep.wp.policy.GetResourceStatus())
+}
+
 func (ep *endpoints) UpdatePolicy(c *gin.Context) {
 	var gsp policy.PolicyPlan
 	c.BindJSON(&gsp)

--- a/app/endpoints.go
+++ b/app/endpoints.go
@@ -13,14 +13,21 @@ type endpoints struct {
 	paused *bool
 }
 
+// GetPolicy returns JSON version of current policy
+// its output is compatible with UpdatePolicy.
 func (ep *endpoints) GetPolicy(c *gin.Context) {
 	c.JSON(200, policy.RecreatePlan(ep.wp.policy))
 }
 
+// GetResourceStatus returns map of resource to count
 func (ep *endpoints) GetResourceStatus(c *gin.Context) {
 	c.JSON(200, ep.wp.policy.GetResourceStatus())
 }
 
+// UpdatePolicy parses body and builds a new policy to replace
+// existing policy
+// returns 200 if policy is well-formed and replaces existing successfully
+// returns 400 if policy is malformed, along with the error message
 func (ep *endpoints) UpdatePolicy(c *gin.Context) {
 	var gsp policy.PolicyPlan
 	c.BindJSON(&gsp)
@@ -42,6 +49,8 @@ func (ep *endpoints) UpdatePolicy(c *gin.Context) {
 	}
 }
 
+// PausePolicy is a utility endpoint that pauses the app and skips
+// the checking-scaling step.
 func (ep *endpoints) PausePolicy(c *gin.Context) {
 	*ep.paused = true
 	c.JSON(200, gin.H{
@@ -49,6 +58,7 @@ func (ep *endpoints) PausePolicy(c *gin.Context) {
 	})
 }
 
+// ResumePolicy is a utility endpoint that resumes the app's checking-scaling cycle
 func (ep *endpoints) ResumePolicy(c *gin.Context) {
 	*ep.paused = false
 	c.JSON(200, gin.H{

--- a/app/router.go
+++ b/app/router.go
@@ -14,6 +14,7 @@ func NewRouter(ep *endpoints) *gin.Engine {
 	})
 
 	router.GET("/state", ep.GetPolicy)
+	router.GET("/status", ep.GetResourceStatus)
 	router.POST("/update", ep.UpdatePolicy)
 
 	// Helper endpoints

--- a/app/router.go
+++ b/app/router.go
@@ -7,12 +7,7 @@ import (
 func NewRouter(ep *endpoints) *gin.Engine {
 	router := gin.Default()
 
-	router.GET("/ping", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"message": "pong",
-		})
-	})
-
+	// Core endpoints
 	router.GET("/state", ep.GetPolicy)
 	router.GET("/status", ep.GetResourceStatus)
 	router.POST("/update", ep.UpdatePolicy)
@@ -20,6 +15,13 @@ func NewRouter(ep *endpoints) *gin.Engine {
 	// Helper endpoints
 	router.PUT("/pause", ep.PausePolicy)
 	router.PUT("/resume", ep.ResumePolicy)
+
+	// Healthcheck
+	router.GET("/ping", func(c *gin.Context) {
+		c.JSON(200, gin.H{
+			"message": "pong",
+		})
+	})
 
 	return router
 }

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -136,3 +136,11 @@ func (p *Policy) Scale(vc *resources.VaultClient) error {
 
 	return nil
 }
+
+func (p *Policy) GetResourceStatus() map[string]int {
+	status := make(map[string]int)
+	for k, v := range p.ResourceMap {
+		status[k] = v.GetNomadClientCount()
+	}
+	return status
+}


### PR DESCRIPTION
**Changes**
* included a GET `/status` endpoint which returns a resource-count map.