### PR TITLE
Implement unique IDs for all resource and subpolicy components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ matrix:
 
 env:
   global:
-  - DOCKER_REGISTRY=registry.gahmen.tech
-  - IMAGE_NAME=${DOCKER_REGISTRY}/l/nomad-parametric-autoscaler
-  - UI_IMAGE_NAME=${DOCKER_REGISTRY}/l/nomad-parametric-autoscaler-ui
+  - IMAGE_NAME=${DOCKER_REGISTRY}/nomad-parametric-autoscaler
+  - UI_IMAGE_NAME=${DOCKER_REGISTRY}/nomad-parametric-autoscaler-ui
   - GITHUB_USER=datagovsg
   - GITHUB_REPONAME=nomad-parametric-autoscaler
 

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -8,6 +8,7 @@ import Topbar from "./components/Topbar";
 import StatusSwitch from "./components/StatusSwitch";
 import PolicySummary from "./containers/PolicySummary";
 import { Button } from "../node_modules/@material-ui/core";
+import { uiToServerConversion, serverToUIConversion } from "./utils/stateConversion";
 
 class App extends Component {
   constructor(props) {
@@ -24,16 +25,8 @@ class App extends Component {
     axios
       .get(`${window.config.env.REACT_APP_NOPAS_ENDPOINT}/state`)
       .then(response => {
-        try {
-          const newState = response.data;
-          for (let sp of newState.Subpolicies) {
-            // convert metadata object to string
-            sp.Metadata = JSON.stringify(sp.Metadata);
-          }
-          this.props.refreshState(newState);
-        } catch (error) {
-          alert(error);
-        }
+        const newState = serverToUIConversion(response.data);
+        newState && this.props.refreshState(newState);
       })
       .catch(function(error) {
         alert(error);
@@ -42,10 +35,8 @@ class App extends Component {
 
   sendUpdate() {
     const state = JSON.parse(JSON.stringify(this.props.state));
-    for (let sp of state.Subpolicies) {
-      sp.Metadata = JSON.parse(sp.Metadata);
-    }
-    axios.post(`${window.config.env.REACT_APP_NOPAS_ENDPOINT}/update`, state);
+    const out = uiToServerConversion(state);
+    out && axios.post(`${window.config.env.REACT_APP_NOPAS_ENDPOINT}/update`, out);
   }
 
   render() {

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -8,7 +8,10 @@ import Topbar from "./components/Topbar";
 import StatusSwitch from "./components/StatusSwitch";
 import PolicySummary from "./containers/PolicySummary";
 import { Button } from "../node_modules/@material-ui/core";
-import { uiToServerConversion, serverToUIConversion } from "./utils/stateConversion";
+import {
+  uiToServerConversion,
+  serverToUIConversion
+} from "./utils/stateConversion";
 
 class App extends Component {
   constructor(props) {
@@ -22,8 +25,13 @@ class App extends Component {
   }
 
   refreshState() {
+    const reqUrl = new URL(
+      "/state",
+      window.config.env.REACT_APP_NOPAS_ENDPOINT
+    );
+
     axios
-      .get(`${window.config.env.REACT_APP_NOPAS_ENDPOINT}/state`)
+      .get(reqUrl)
       .then(response => {
         const newState = serverToUIConversion(response.data);
         newState && this.props.refreshState(newState);
@@ -36,7 +44,11 @@ class App extends Component {
   sendUpdate() {
     const state = JSON.parse(JSON.stringify(this.props.state));
     const out = uiToServerConversion(state);
-    out && axios.post(`${window.config.env.REACT_APP_NOPAS_ENDPOINT}/update`, out);
+    const reqUrl = new URL(
+      "/update",
+      window.config.env.REACT_APP_NOPAS_ENDPOINT
+    );
+    out && axios.post(reqUrl, out);
   }
 
   render() {

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -42,8 +42,7 @@ class App extends Component {
   }
 
   sendUpdate() {
-    const state = JSON.parse(JSON.stringify(this.props.state));
-    const out = uiToServerConversion(state);
+    const out = uiToServerConversion(this.props.state);
     const reqUrl = new URL(
       "/update",
       window.config.env.REACT_APP_NOPAS_ENDPOINT

--- a/ui/src/components/ManagedResources.jsx
+++ b/ui/src/components/ManagedResources.jsx
@@ -5,15 +5,16 @@ import { CardContent } from "@material-ui/core";
 import Fab from "@material-ui/core/Fab";
 import DeleteIcon from "@material-ui/icons/Delete";
 import AddIcon from "@material-ui/icons/Add";
+import _ from 'lodash';
 
 const ManagedResources = props => {
-  const { name, resources } = props;
+  const { id, resources } = props;
 
   const deleteSubpolicyResource = resourceName => () => {
     let newResource = resources.slice().filter(r => r !== resourceName);
 
     props.updateSubpolicyResource({
-      name: name,
+      id: id,
       newManagedResources: newResource
     });
   };
@@ -23,7 +24,7 @@ const ManagedResources = props => {
     const idx = newResource.findIndex(val => val === resourceName);
     newResource[idx] = event.target.value;
     props.updateSubpolicyResource({
-      name: name,
+      id: id,
       newManagedResources: newResource
     });
   };
@@ -32,7 +33,7 @@ const ManagedResources = props => {
     let newResource = resources.slice();
     newResource.push("");
     props.updateSubpolicyResource({
-      name: name,
+      id: id,
       newManagedResources: newResource
     });
   };
@@ -65,7 +66,7 @@ const ManagedResources = props => {
 };
 
 ManagedResources.propTypes = {
-  name: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
   resources: PropTypes.arrayOf(PropTypes.string).isRequired,
   updateSubpolicyResource: PropTypes.func.isRequired
 };

--- a/ui/src/components/Resource.jsx
+++ b/ui/src/components/Resource.jsx
@@ -12,11 +12,11 @@ import NomadParameters from "../containers/NomadParameters";
 import EC2Parameters from "../containers/EC2Parameters";
 
 const Resource = props => {
-  const { name } = props;
+  const { id } = props;
 
   const updateField = field => event => {
     props.updateResourceField({
-      name: name,
+      id: id,
       value: event.target.value,
       field: field
     });
@@ -24,18 +24,18 @@ const Resource = props => {
 
   const updateNumericField = field => event => {
     props.updateNumericResourceField({
-      name: name,
+      id: id,
       value: event.target.value,
       field: field
     });
   };
 
   const deleteResource = () => {
-    props.deleteResource({ name: name });
+    props.deleteResource({ id: id });
   };
 
   const renameResource = event => {
-    props.updateResourceName({ oldName: name, newName: event.target.value });
+    props.updateResourceName({ id: id, newName: event.target.value });
   };
 
   // resource will contain details for ratio, cooldown,
@@ -47,7 +47,7 @@ const Resource = props => {
           required
           id="standard-required"
           label="Resource Name"
-          value={name}
+          value={props.resourceName}
           onChange={renameResource}
           margin="normal"
         />
@@ -85,14 +85,15 @@ const Resource = props => {
           <DeleteIcon />
         </Fab>
       </CardContent>
-      <NomadParameters name={name} />
-      <EC2Parameters name={name} />
+      <NomadParameters name={id} />
+      <EC2Parameters name={id} />
     </Card>
   );
 };
 
 Resource.propTypes = {
-  name: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  resourceName: PropTypes.string.isRequired,
   scaleInCooldown: PropTypes.string.isRequired,
   scaleOutCooldown: PropTypes.string.isRequired,
   ratio: PropTypes.number.isRequired,

--- a/ui/src/components/ResourceGroup.jsx
+++ b/ui/src/components/ResourceGroup.jsx
@@ -12,7 +12,7 @@ const ResourceGroup = props => {
     <div>
       <Paper elevation={1}>
         {resources.map(r => (
-          <Resource key={r} name={r} />
+          <Resource key={r} id={r} />
         ))}
       </Paper>
       <Button size="small" color="primary" onClick={props.createResource}>

--- a/ui/src/components/Subpolicy.jsx
+++ b/ui/src/components/Subpolicy.jsx
@@ -10,7 +10,7 @@ import ManagedResources from "../containers/ManagedResources";
 const Subpolicy = props => {
   const { id, name, resources, metadata } = props;
   const updateField = event => {
-    props.updateMeta({ id: name, value: event.target.value });
+    props.updateMeta({ id: id, value: event.target.value });
   };
 
   const deleteSubpolicy = () => {
@@ -34,7 +34,7 @@ const Subpolicy = props => {
           onChange={renameSubpolicy}
           margin="normal"
         />
-        <ManagedResources name={name} resources={resources} />
+        <ManagedResources id={id} resources={resources} />
         <TextField
           required
           multiline

--- a/ui/src/components/Subpolicy.jsx
+++ b/ui/src/components/Subpolicy.jsx
@@ -8,17 +8,17 @@ import DeleteIcon from "@material-ui/icons/Delete";
 import ManagedResources from "../containers/ManagedResources";
 
 const Subpolicy = props => {
-  const { name, resources, metadata } = props;
+  const { id, name, resources, metadata } = props;
   const updateField = event => {
-    props.updateMeta({ name: name, value: event.target.value });
+    props.updateMeta({ id: name, value: event.target.value });
   };
 
   const deleteSubpolicy = () => {
-    props.deleteSubpolicy({ name: name });
+    props.deleteSubpolicy({ id: id });
   };
 
   const renameSubpolicy = event => {
-    props.updateSubpolicyName({ oldName: name, newName: event.target.value });
+    props.updateSubpolicyName({ id: id, newName: event.target.value });
   };
 
   // resource will contain details for ratio, cooldown,
@@ -59,6 +59,7 @@ const Subpolicy = props => {
 };
 
 Subpolicy.propTypes = {
+  id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   resources: PropTypes.arrayOf(PropTypes.string).isRequired,
   metadata: PropTypes.string.isRequired,

--- a/ui/src/components/SubpolicyGroup.jsx
+++ b/ui/src/components/SubpolicyGroup.jsx
@@ -12,7 +12,7 @@ const SubpolicyGroup = props => {
     <div>
       <Paper elevation={1}>
         {subpolicies.map(sp => (
-          <Subpolicy key={sp} name={sp} />
+          <Subpolicy key={sp} id={sp} />
         ))}
       </Paper>
       <Button size="small" color="primary" onClick={props.createSubpolicy}>

--- a/ui/src/containers/Resource.js
+++ b/ui/src/containers/Resource.js
@@ -9,9 +9,10 @@ import {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    scaleInCooldown: state.policy.Resources[ownProps.name].ScaleInCooldown,
-    scaleOutCooldown: state.policy.Resources[ownProps.name].ScaleOutCooldown,
-    ratio: state.policy.Resources[ownProps.name].N2CRatio
+    resourceName: state.policy.Resources[ownProps.id].Name,
+    scaleInCooldown: state.policy.Resources[ownProps.id].ScaleInCooldown,
+    scaleOutCooldown: state.policy.Resources[ownProps.id].ScaleOutCooldown,
+    ratio: state.policy.Resources[ownProps.id].N2CRatio
   };
 };
 

--- a/ui/src/containers/Subpolicy.js
+++ b/ui/src/containers/Subpolicy.js
@@ -4,11 +4,12 @@ import { updateSubpolicyName, deleteSubpolicy, updateMeta } from "../actions";
 
 const mapStateToProps = (state, ownProps) => {
   const thisSP = state.policy.Subpolicies.filter(
-    sp => sp.Name === ownProps.name
+    sp => sp.Id === ownProps.id
   );
   const sp = thisSP && thisSP[0];
 
   return {
+    name: sp.Name,
     metadata: sp.Metadata,
     resources: sp.ManagedResources
   };

--- a/ui/src/containers/SubpolicyGroup.js
+++ b/ui/src/containers/SubpolicyGroup.js
@@ -5,7 +5,7 @@ import { createSubpolicy } from "../actions";
 
 const mapStateToProps = state => {
   return {
-    subpolicies: state.policy.Subpolicies.map(sp => sp.Name)
+    subpolicies: state.policy.Subpolicies.map(sp => sp.Id)
   };
 };
 

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -160,7 +160,9 @@ export const policy = (state = initialState, action) => {
     case UPDATE_RESOURCE_NUMERIC_FIELD:
       let resourceNumericField = parseInt(action.change.value, 10);
       if (resourceNumericField) {
-        updatedResource[action.change.id][action.change.field] = resourceNumericField;
+        updatedResource[action.change.id][
+          action.change.field
+        ] = resourceNumericField;
         return {
           ...state,
           Resources: updatedResource
@@ -200,19 +202,18 @@ export const policy = (state = initialState, action) => {
       };
 
     case UPDATE_EC2_NUMERIC_PARAM:
-    let ec2NumericParam = parseInt(action.change.value, 10);
-    if (ec2NumericParam) {
-      updatedResource[action.change.name].EC2[
-        action.change.field
-      ] = ec2NumericParam;
-      return {
-        ...state,
-        Resources: updatedResource
-      };
-    } else {
-      return state;
-    }
-
+      let ec2NumericParam = parseInt(action.change.value, 10);
+      if (ec2NumericParam) {
+        updatedResource[action.change.name].EC2[
+          action.change.field
+        ] = ec2NumericParam;
+        return {
+          ...state,
+          Resources: updatedResource
+        };
+      } else {
+        return state;
+      }
 
     case CREATE_SUBPOLICY:
       sp.push({
@@ -228,8 +229,7 @@ export const policy = (state = initialState, action) => {
       };
 
     case UPDATE_SUBPOLICY_NAME:
-
-    // make sure no current SP have that name
+      // make sure no current SP have that name
       for (let i = 0; i < sp.length; i++) {
         if (sp[i].Id === action.change.id) {
           sp[i].Name = action.change.newName;

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -1,5 +1,6 @@
 import remove from "lodash/remove";
 import { combineReducers } from "redux";
+import { uniqueIdGen } from "../utils/uniqueIdGenerator";
 
 import {
   UPDATE_STATE,
@@ -27,7 +28,7 @@ export const initialState = {
   CheckingFreq: "1m",
   Ensembler: "conservative",
   Resources: {
-    Sample: {
+    uuid1: {
       Name: "Sample",
       Nomad: {
         Address: "",
@@ -46,7 +47,7 @@ export const initialState = {
       ScaleInCooldown: "2m",
       N2CRatio: 0
     },
-    Sample2: {
+    uuid2: {
       Name: "Sample2",
       Nomad: {
         Address: "",
@@ -110,7 +111,8 @@ export const policy = (state = initialState, action) => {
 
     case CREATE_RESOURCE:
       // TODO: get refactor
-      updatedResource["New"] = {
+      updatedResource[uniqueIdGen()] = {
+        Name: "",
         Nomad: {
           Address: "",
           JobName: "",
@@ -134,23 +136,21 @@ export const policy = (state = initialState, action) => {
       };
 
     case DELETE_RESOURCE:
-      delete updatedResource[action.change.name];
+      delete updatedResource[action.change.id];
       return {
         ...state,
         Resources: updatedResource
       };
 
     case UPDATE_RESOURCE_NAME:
-      updatedResource[action.change.newName] =
-        updatedResource[action.change.oldName];
-      delete updatedResource[action.change.oldName];
+      updatedResource[action.change.id].Name = action.change.newName;
       return {
         ...state,
         Resources: updatedResource
       };
 
     case UPDATE_RESOURCE_FIELD:
-      updatedResource[action.change.name][action.change.field] =
+      updatedResource[action.change.id][action.change.field] =
         action.change.value;
       return {
         ...state,
@@ -160,7 +160,7 @@ export const policy = (state = initialState, action) => {
     case UPDATE_RESOURCE_NUMERIC_FIELD:
       let resourceNumericField = parseInt(action.change.value, 10);
       if (resourceNumericField) {
-        updatedResource[action.change.name][action.change.field] = resourceNumericField;
+        updatedResource[action.change.id][action.change.field] = resourceNumericField;
         return {
           ...state,
           Resources: updatedResource
@@ -216,7 +216,8 @@ export const policy = (state = initialState, action) => {
 
     case CREATE_SUBPOLICY:
       sp.push({
-        Name: "new",
+        Id: uniqueIdGen(),
+        Name: "",
         ManagedResources: [],
         Metadata: ""
       });
@@ -230,7 +231,7 @@ export const policy = (state = initialState, action) => {
 
     // make sure no current SP have that name
       for (let i = 0; i < sp.length; i++) {
-        if (sp[i].Name === action.change.oldName) {
+        if (sp[i].Id === action.change.id) {
           sp[i].Name = action.change.newName;
           break;
         }
@@ -243,7 +244,7 @@ export const policy = (state = initialState, action) => {
 
     case UPDATE_SP_RESOURCE:
       for (let i = 0; i < sp.length; i++) {
-        if (sp[i].Name === action.change.name) {
+        if (sp[i].Id === action.change.id) {
           sp[i].ManagedResources = action.change.value; // TODO thsi implementation is wrong
           break;
         }
@@ -256,7 +257,7 @@ export const policy = (state = initialState, action) => {
 
     case UPDATE_SUBPOLICY_RESOURCE:
       for (let i = 0; i < sp.length; i++) {
-        if (sp[i].Name === action.change.name) {
+        if (sp[i].Id === action.change.id) {
           sp[i].ManagedResources = action.change.newManagedResources;
           break;
         }
@@ -269,7 +270,7 @@ export const policy = (state = initialState, action) => {
 
     case UPDATE_SP_META:
       for (let i = 0; i < sp.length; i++) {
-        if (sp[i].Name === action.change.name) {
+        if (sp[i].Id === action.change.id) {
           sp[i].Metadata = action.change.value;
           break;
         }
@@ -281,7 +282,7 @@ export const policy = (state = initialState, action) => {
 
     case DELETE_SUBPOLICY: {
       const newSP = remove(sp, elem => {
-        return elem.Name !== action.change.name;
+        return elem.Id !== action.change.id;
       });
 
       return {

--- a/ui/src/utils/stateConversion.js
+++ b/ui/src/utils/stateConversion.js
@@ -1,0 +1,52 @@
+import { uniqueIdGen } from "./uniqueIdGenerator";
+
+export const serverToUIConversion = input => {
+  try {
+    // subpolicy stringify + give Id
+    for (let sp of input.Subpolicies) {
+      sp.Metadata = JSON.stringify(sp.Metadata);
+      sp["Id"] = uniqueIdGen();
+    }
+
+    // resource naming
+    let resource = {};
+    for (let key in input.Resources) {
+      if (input.Resources.hasOwnProperty(key)) {
+        resource[uniqueIdGen()] = {
+          ...input.Resources[key],
+          Name: key
+        };
+      }
+    }
+    return {
+      ...input,
+      Resources: resource
+    };
+  } catch (error) {
+    alert(error);
+  }
+};
+
+export const uiToServerConversion = state => {
+  // put resource name as key
+  try {
+    let resource = {};
+    for (let key in state.Resources) {
+      if (state.Resources.hasOwnProperty(key)) {
+        const name = state.Resources[key].Name;
+        resource[name] = state.Resources[key];
+      }
+    }
+
+    for (let sp of state.Subpolicies) {
+      sp.Metadata = JSON.parse(sp.Metadata);
+    }
+
+    return {
+      ...state,
+      Resources: resource
+    };
+  } catch (error) {
+    alert(error);
+  }
+};

--- a/ui/src/utils/stateConversion.js
+++ b/ui/src/utils/stateConversion.js
@@ -3,14 +3,14 @@ import { uniqueIdGen } from "./uniqueIdGenerator";
 export const serverToUIConversion = input => {
   try {
     // subpolicy stringify + give Id
-    for (let sp of input.Subpolicies) {
+    for (const sp of input.Subpolicies) {
       sp.Metadata = JSON.stringify(sp.Metadata);
       sp["Id"] = uniqueIdGen();
     }
 
     // resource naming
-    let resource = {};
-    for (let key in input.Resources) {
+    const resource = {};
+    for (const key in input.Resources) {
       if (input.Resources.hasOwnProperty(key)) {
         resource[uniqueIdGen()] = {
           ...input.Resources[key],
@@ -27,18 +27,18 @@ export const serverToUIConversion = input => {
   }
 };
 
-export const uiToServerConversion = state => {
-  // put resource name as key
+export const uiToServerConversion = input => {
   try {
-    let resource = {};
-    for (let key in state.Resources) {
+    const state = JSON.parse(JSON.stringify(input));
+    const resource = {};
+    for (const key in state.Resources) {
       if (state.Resources.hasOwnProperty(key)) {
         const name = state.Resources[key].Name;
         resource[name] = state.Resources[key];
       }
     }
 
-    for (let sp of state.Subpolicies) {
+    for (const sp of state.Subpolicies) {
       sp.Metadata = JSON.parse(sp.Metadata);
     }
 

--- a/ui/src/utils/uniqueIdGenerator.js
+++ b/ui/src/utils/uniqueIdGenerator.js
@@ -1,0 +1,12 @@
+// from https://gist.github.com/gordonbrander/2230317
+export const uniqueIdGen = () => {
+  // Math.random should be unique because of its seeding algorithm.
+  // Convert it to base 36 (numbers + letters), and grab the first 9 characters
+  // after the decimal.
+  return (
+    "_" +
+    Math.random()
+      .toString(36)
+      .substr(2, 9)
+  );
+};

--- a/ui/tests/components/ManagedResources.test.js
+++ b/ui/tests/components/ManagedResources.test.js
@@ -14,7 +14,7 @@ const store = mockStore(initialState);
 
 function shallowSetup() {
   const props = {
-    name: "test",
+    id: "test",
     resources: ["a", "b", "c"],
     updateSubpolicyResource: jest.fn()
   };

--- a/ui/tests/components/Resource.test.js
+++ b/ui/tests/components/Resource.test.js
@@ -9,7 +9,8 @@ import NomadParameters from "../../src/containers/NomadParameters";
 
 function shallowSetup() {
   const props = {
-    name: "test",
+    id: "id",
+    resourceName: "test",
     scaleInCooldown: "1m",
     scaleOutCooldown: "1m30s",
     ratio: 3,

--- a/ui/tests/components/Subpolicy.test.js
+++ b/ui/tests/components/Subpolicy.test.js
@@ -18,6 +18,7 @@ const store = mockStore(initialState);
 function shallowSetup() {
   // Sample props to pass to our shallow render
   const props = {
+    id: "id",
     name: "test",
     resources: ["1", "2"],
     metadata: "meta",

--- a/ui/tests/reducers/reducers.test.js
+++ b/ui/tests/reducers/reducers.test.js
@@ -42,41 +42,25 @@ describe("Actions", () => {
     expect(output2.Ensembler).toEqual(newFreq);
   });
 
-  it("New resource created should match template", () => {
+  it("create new resources", () => {
+    expect(Object.keys(initialState.Resources).length).toEqual(2);
     const out = policy(initialState, {
       type: CREATE_RESOURCE
     });
-    expect(out.Resources.New).toEqual({
-      Nomad: {
-        Address: "",
-        JobName: "",
-        NomadPath: "",
-        MaxCount: 10,
-        MinCount: 1
-      },
-      EC2: {
-        ScalingGroupName: "asg name",
-        Region: "ap-southeast-1",
-        MaxCount: 10,
-        MinCount: 1
-      },
-      ScaleOutCooldown: "1m",
-      ScaleInCooldown: "2m",
-      N2CRatio: 0
-    });
+    expect(Object.keys(out.Resources).length).toEqual(3);
   });
 
   it("should delete resources", () => {
     expect(Object.keys(initialState.Resources).length).toEqual(2);
     const out = policy(initialState, {
       type: DELETE_RESOURCE,
-      change: { name: "Sample" }
+      change: { id: "uuid1" }
     });
 
     expect(Object.keys(out.Resources).length).toEqual(1);
     const out2 = policy(out, {
       type: DELETE_RESOURCE,
-      change: { name: "Sample2" }
+      change: { id: "uuid2" }
     });
     expect(Object.keys(out.Resources).length).toEqual(1);
     expect(Object.keys(out2.Resources).length).toEqual(0);
@@ -86,41 +70,41 @@ describe("Actions", () => {
     expect(Object.keys(initialState.Resources).length).toEqual(2);
     const out = policy(initialState, {
       type: DELETE_RESOURCE,
-      change: { name: "Sample3" }
+      change: { id: "uuid3" }
     });
     expect(Object.keys(out.Resources).length).toEqual(2);
   });
 
   it("should change resource field correctly", () => {
-    const change = { name: "Sample2", field: "ScaleOutCooldown", value: "13" };
+    const change = { id: "uuid2", field: "ScaleOutCooldown", value: "13" };
     const out = policy(initialState, {
       type: UPDATE_RESOURCE_FIELD,
       change: change
     });
 
-    expect(out.Resources[change.name].ScaleOutCooldown).toEqual(change.value);
+    expect(out.Resources[change.id].ScaleOutCooldown).toEqual(change.value);
   });
 
   it("should change resource numeric field correctly", () => {
-    const change = { name: "Sample2", field: "N2CRatio", value: 12 };
+    const change = { id: "uuid2", field: "N2CRatio", value: 12 };
     const out = policy(initialState, {
       type: UPDATE_RESOURCE_NUMERIC_FIELD,
       change: change
     });
-    expect(out.Resources[change.name].N2CRatio).toEqual(change.value);
+    expect(out.Resources[change.id].N2CRatio).toEqual(change.value);
 
-    const incorrect = { name: "Sample2", field: "N2CRatio", value: "hi" };
+    const incorrect = { id: "uuid2", field: "N2CRatio", value: "hi" };
     const out2 = policy(initialState, {
       type: UPDATE_RESOURCE_NUMERIC_FIELD,
       change: incorrect
     });
-    expect(out2.Resources[change.name].N2CRatio).toEqual(
-      initialState.Resources[change.name].N2CRatio
+    expect(out2.Resources[change.id].N2CRatio).toEqual(
+      initialState.Resources[change.id].N2CRatio
     );
   });
 
   it("should change resource's nomad param correctly", () => {
-    const change = { name: "Sample2", field: "Address", value: "13" };
+    const change = { name: "uuid2", field: "Address", value: "13" };
     const out = policy(initialState, {
       type: UPDATE_NOMAD_PARAM,
       change: change
@@ -130,14 +114,14 @@ describe("Actions", () => {
   });
 
   it("should change resource nomad numeric field correctly", () => {
-    const change = { name: "Sample2", field: "MaxCount", value: 12 };
+    const change = { name: "uuid2", field: "MaxCount", value: 12 };
     const out = policy(initialState, {
       type: UPDATE_NOMAD_NUMERIC_PARAM,
       change: change
     });
     expect(out.Resources[change.name].Nomad.MaxCount).toEqual(change.value);
 
-    const incorrect = { name: "Sample2", field: "MaxCount", value: "hi" };
+    const incorrect = { name: "uuid2", field: "MaxCount", value: "hi" };
     const out2 = policy(initialState, {
       type: UPDATE_NOMAD_NUMERIC_PARAM,
       change: incorrect
@@ -148,7 +132,7 @@ describe("Actions", () => {
   });
 
   it("should change resource's EC2 param correctly", () => {
-    const change = { name: "Sample2", field: "ScalingGroupName", value: "13" };
+    const change = { name: "uuid2", field: "ScalingGroupName", value: "13" };
     const out = policy(initialState, {
       type: UPDATE_EC2_PARAM,
       change: change
@@ -160,14 +144,14 @@ describe("Actions", () => {
   });
 
   it("should change resource EC2 numeric field correctly", () => {
-    const change = { name: "Sample2", field: "MaxCount", value: 12 };
+    const change = { name: "uuid2", field: "MaxCount", value: 12 };
     const out = policy(initialState, {
       type: UPDATE_EC2_NUMERIC_PARAM,
       change: change
     });
     expect(out.Resources[change.name].EC2.MaxCount).toEqual(change.value);
 
-    const incorrect = { name: "Sample2", field: "MaxCount", value: "hi" };
+    const incorrect = { name: "uuid2", field: "MaxCount", value: "hi" };
     const out2 = policy(initialState, {
       type: UPDATE_EC2_NUMERIC_PARAM,
       change: incorrect


### PR DESCRIPTION
Refer to issue #9 

Changes
* implemented two helper functions to **convert internal state into a JSON format** which is recognisable by nopas backend. Reason for this is that the backend care about ids of the resource/sub-policies. The IDs are only used on the frontend to distinguish between components which may have the same name. cleaning up the JSON before sending it will keep the API body clean and usable for manual calls via cmd-line or Postman.
* borrowed a random id generating function (credited in file)