### PR TITLE
Enable scaler to react to change in max/min count

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,9 +97,8 @@ require (
 	github.com/ugorji/go/codec v0.0.0-20190204201341-e444a5086c43 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.opencensus.io v0.19.1 // indirect
-	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
-	golang.org/x/net v0.0.0-20190227160552-c95aed5357e7 // indirect
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
+	golang.org/x/tools v0.0.0-20190619215442-4adf7a708c2d // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -576,6 +576,8 @@ golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20181112044915-a3060d491354/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -592,6 +594,8 @@ golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7 h1:C2F/nMkR/9sfUTpvR3QrjBuTdvMUC/cFajkphs1YLQo=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890 h1:uESlIz09WIHT2I+pasSXcpLYqYK8wHcdCetU3VuMBJE=
@@ -600,6 +604,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180828065106-d99a578cf41b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -616,6 +621,8 @@ golang.org/x/sys v0.0.0-20181218192612-074acd46bca6/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181228144115-9a3f9b0469bb/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc h1:WiYx1rIFmx8c0mXAFtv5D/mHyKe1+jmuP7PViuwqwuQ=
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -625,6 +632,8 @@ golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181219222714-6e267b5cc78e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181221154417-3ad2d988d5e2/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190619215442-4adf7a708c2d h1:LQ06Vbju+Kwbcd94hb+6CgDsWoj/e7GOLPcYzHrG+iI=
+golang.org/x/tools v0.0.0-20190619215442-4adf7a708c2d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 google.golang.org/api v0.0.0-20181021000519-a2651947f503/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/resources/ec2_client.go
+++ b/resources/ec2_client.go
@@ -21,8 +21,8 @@ type EC2AutoScalingGroup struct {
 	Region           string `json:"Region"`
 
 	awsScalingProvider *autoscaling.AutoScaling
-	maxscale           int
-	minscale           int
+	MaxCount           int
+	MinCount           int
 }
 
 type EC2AutoScalingGroupPlan struct {
@@ -38,13 +38,13 @@ func (asgp EC2AutoScalingGroupPlan) ApplyPlan() *EC2AutoScalingGroup {
 }
 
 // NewEC2AutoScalingGroup factory function
-func NewEC2AutoScalingGroup(region string, gpName string, maxscale int, minscale int) *EC2AutoScalingGroup {
+func NewEC2AutoScalingGroup(region string, gpName string, maxCount int, minCount int) *EC2AutoScalingGroup {
 	return &EC2AutoScalingGroup{
 		awsScalingProvider: newAwsAsgService(region),
 		ScalingGroupName:   gpName,
 		Region:             region,
-		maxscale:           maxscale,
-		minscale:           minscale,
+		MaxCount:           maxCount,
+		MinCount:           minCount,
 	}
 }
 
@@ -138,16 +138,16 @@ func (easg EC2AutoScalingGroup) RecreatePlan() EC2AutoScalingGroupPlan {
 	return EC2AutoScalingGroupPlan{
 		ScalingGroupName: easg.ScalingGroupName,
 		Region:           easg.Region,
-		MaxCount:         easg.maxscale,
-		MinCount:         easg.minscale,
+		MaxCount:         easg.MaxCount,
+		MinCount:         easg.MinCount,
 	}
 }
 
 func (easg EC2AutoScalingGroup) getValidScaleCount(newCount int) int {
-	if newCount > easg.maxscale {
-		newCount = easg.maxscale
-	} else if newCount < easg.minscale {
-		newCount = easg.minscale
+	if newCount > easg.MaxCount {
+		newCount = easg.MaxCount
+	} else if newCount < easg.MinCount {
+		newCount = easg.MinCount
 	}
 	return newCount
 }

--- a/resources/nomad_client.go
+++ b/resources/nomad_client.go
@@ -18,8 +18,8 @@ type NomadClient struct {
 	JobName   string
 	NomadPath string
 	client    nomadClient
-	maxCount  int
-	minCount  int
+	MaxCount  int
+	MinCount  int
 	address   string
 }
 
@@ -53,8 +53,8 @@ func NewNomadClient(vc VaultClient, addr string, name string, minCount int, maxC
 	return &NomadClient{
 		JobName:   name,
 		NomadPath: nomadPath,
-		maxCount:  maxCount,
-		minCount:  minCount,
+		MaxCount:  maxCount,
+		MinCount:  minCount,
 		client: nomadClient{
 			nomad: client,
 		},
@@ -107,10 +107,10 @@ func (nc NomadClient) getNomadJob() (*nomad.Job, error) {
 }
 
 func (nc NomadClient) getValidScaleCount(newCount int) int {
-	if newCount > nc.maxCount {
-		newCount = nc.maxCount
-	} else if newCount < nc.minCount {
-		newCount = nc.minCount
+	if newCount > nc.MaxCount {
+		newCount = nc.MaxCount
+	} else if newCount < nc.MinCount {
+		newCount = nc.MinCount
 	}
 	return newCount
 }
@@ -120,7 +120,7 @@ func (nc NomadClient) RecreatePlan() NomadClientPlan {
 		Address:   nc.address,
 		JobName:   nc.JobName,
 		NomadPath: nc.NomadPath,
-		MaxCount:  nc.maxCount,
-		MinCount:  nc.minCount,
+		MaxCount:  nc.MaxCount,
+		MinCount:  nc.MinCount,
 	}
 }

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -72,17 +72,18 @@ func (res *EC2NomadResource) Scale(desiredNomadCount int, vc *VaultClient) error
 		return err
 	}
 
-	if count < desiredNomadCount {
-		return res.scaleOut(desiredNomadCount, vc)
-	} else if count > desiredNomadCount {
-		return res.scaleIn(desiredNomadCount, vc)
-	}
-
 	// limit violation requires correction
 	if count < res.NomadClient.MinCount {
 		return res.scaleOut(res.NomadClient.MinCount, vc)
 	} else if count > res.NomadClient.MaxCount {
 		return res.scaleIn(res.NomadClient.MaxCount, vc)
+	}
+
+	// scale accordingly
+	if count < desiredNomadCount {
+		return res.scaleOut(desiredNomadCount, vc)
+	} else if count > desiredNomadCount {
+		return res.scaleIn(desiredNomadCount, vc)
 	} else {
 		return nil
 	}

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -66,9 +66,9 @@ func (rp ResourcePlan) ApplyPlan(name string, vc VaultClient) (Resource, error) 
 func (res *EC2NomadResource) Scale(desiredNomadCount int, vc *VaultClient) error {
 	// check if its a scale out or scale in
 	if count, err := res.NomadClient.GetTaskGroupCount(); err == nil {
-		if count < desiredNomadCount { // scale out
+		if count < desiredNomadCount || count < res.NomadClient.MinCount || count < res.EC2AutoScalingGroup.MinCount { // scale out
 			return res.scaleOut(desiredNomadCount, vc)
-		} else if count > desiredNomadCount {
+		} else if count > desiredNomadCount || count > res.NomadClient.MaxCount || count > res.EC2AutoScalingGroup.MaxCount {
 			return res.scaleIn(desiredNomadCount, vc)
 		} else {
 			return nil


### PR DESCRIPTION
Previously the scaler triggers a scale only when count does not match
the desired count, ignoring upper and lower limits. When the limit
changes, a scale out/in should trigger if limits are crossed.

Refer to #20 .