### PR TITLE
Implement daily schedule sp

### DIFF
--- a/policy/subpolicy/daily_schedule_subpolicy.go
+++ b/policy/subpolicy/daily_schedule_subpolicy.go
@@ -1,0 +1,109 @@
+package subpolicy
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/datagovsg/nomad-parametric-autoscaler/resources"
+	"github.com/mitchellh/mapstructure"
+)
+
+// OfficeHourSubPolicy is a subpolicy that extends the `SubPolicy` interface
+// and takes in the GenericSubpolicy struct
+type DailyScheduleSubPolicy struct {
+	Name             string
+	managedResources []resources.Resource
+	metadata         DailyScheduleSubPolicyMetadata
+}
+
+type ScalingWindow struct {
+	Begin int `json:"Begin"`
+	End   int `json:"End"`
+	Count int `json:"Count"`
+}
+
+func (sw ScalingWindow) IsInWindow(time int) bool {
+	return sw.Begin <= time && time < sw.End
+}
+
+// OfficeHourSubPolicyMetadata represents metadata unique to OfficeHourSubPolicy
+type DailyScheduleSubPolicyMetadata struct {
+	Default  *int            `json:"Default"`
+	Schedule []ScalingWindow `json:"Schedule"`
+}
+
+func NewDailyScheduleSubPolicy(name string, mr []resources.Resource, meta interface{}) (*DailyScheduleSubPolicy, error) {
+	var decoded DailyScheduleSubPolicyMetadata
+	mapstructure.Decode(meta, &decoded)
+
+	if err := verifyDailyScheduleMetadata(decoded); err != nil {
+		return nil, err
+	}
+
+	fmt.Println(meta)
+	fmt.Println(decoded.Schedule[0].Count)
+
+	return &DailyScheduleSubPolicy{
+		Name:             name,
+		managedResources: mr,
+		metadata:         decoded,
+	}, nil
+}
+
+func verifyDailyScheduleMetadata(meta DailyScheduleSubPolicyMetadata) error {
+	if meta.Default == nil {
+		return fmt.Errorf("Default missing from DailyScheduleSubPolicyMetadata")
+	}
+
+	if meta.Schedule == nil {
+		return fmt.Errorf("Schedule missing from DailyScheduleSubPolicyMetadata")
+	}
+
+	return nil
+}
+
+func (dssp DailyScheduleSubPolicy) GetManagedResources() []resources.Resource {
+	return dssp.managedResources
+}
+
+func (dssp *DailyScheduleSubPolicy) RecommendCount() map[resources.Resource]int {
+	now := time.Now().UTC()
+	currentTime := (now.Hour()+8)*100 + now.Minute()
+
+	output := make(map[resources.Resource]int)
+
+	// if within office hour, scale-up, else scale-down
+	for _, resc := range dssp.managedResources {
+		var recommendation int
+		windowExist := false
+		for _, sw := range dssp.metadata.Schedule {
+			if sw.IsInWindow(currentTime) {
+				recommendation = sw.Count
+				windowExist = true
+				break
+			}
+		}
+
+		if !windowExist {
+			recommendation = *dssp.metadata.Default
+		}
+
+		output[resc] = recommendation
+	}
+	return output
+}
+
+func (dssp *DailyScheduleSubPolicy) DeriveGenericSubpolicy() GenericSubPolicy {
+	resourceNameList := make([]string, 0)
+	for _, r := range dssp.managedResources {
+		resourceNameList = append(resourceNameList, r.ResourceName())
+	}
+
+	fmt.Println(dssp.metadata)
+
+	return GenericSubPolicy{
+		Name:             dssp.Name,
+		ManagedResources: resourceNameList,
+		Metadata:         dssp.metadata,
+	}
+}

--- a/policy/subpolicy/daily_schedule_subpolicy.go
+++ b/policy/subpolicy/daily_schedule_subpolicy.go
@@ -2,6 +2,7 @@ package subpolicy
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/datagovsg/nomad-parametric-autoscaler/resources"
@@ -67,8 +68,9 @@ func (dssp DailyScheduleSubPolicy) GetManagedResources() []resources.Resource {
 }
 
 func (dssp *DailyScheduleSubPolicy) RecommendCount() map[resources.Resource]int {
-	now := time.Now().UTC()
-	currentTime := (now.Hour()+8)*100 + now.Minute()
+	loc, _ := time.LoadLocation(getenv("TZ", "Asia/Singapore"))
+	now := time.Now().In(loc)
+	currentTime := (now.Hour())*100 + now.Minute()
 
 	output := make(map[resources.Resource]int)
 
@@ -106,4 +108,12 @@ func (dssp *DailyScheduleSubPolicy) DeriveGenericSubpolicy() GenericSubPolicy {
 		ManagedResources: resourceNameList,
 		Metadata:         dssp.metadata,
 	}
+}
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
 }

--- a/policy/subpolicy/daily_schedule_subpolicy.go
+++ b/policy/subpolicy/daily_schedule_subpolicy.go
@@ -2,10 +2,9 @@ package subpolicy
 
 import (
 	"fmt"
-	"os"
-	"time"
 
 	"github.com/datagovsg/nomad-parametric-autoscaler/resources"
+	"github.com/datagovsg/nomad-parametric-autoscaler/utils"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -65,15 +64,7 @@ func (dssp DailyScheduleSubPolicy) GetManagedResources() []resources.Resource {
 }
 
 func (dssp *DailyScheduleSubPolicy) RecommendCount() map[resources.Resource]int {
-	loc, err := time.LoadLocation(getenv("TZ", "Asia/Singapore"))
-	var now time.Time
-	if err != nil {
-		now = time.Now().UTC().Add(8 * time.Hour)
-	} else {
-		now = time.Now().In(loc)
-	}
-
-	currentTime := (now.Hour())*100 + now.Minute()
+	currentTime := utils.GetCurrentTimeHHMM()
 
 	output := make(map[resources.Resource]int)
 
@@ -104,18 +95,9 @@ func (dssp *DailyScheduleSubPolicy) DeriveGenericSubpolicy() GenericSubPolicy {
 		resourceNameList = append(resourceNameList, r.ResourceName())
 	}
 
-	fmt.Println(dssp.metadata)
-
 	return GenericSubPolicy{
 		Name:             dssp.Name,
 		ManagedResources: resourceNameList,
 		Metadata:         dssp.metadata,
 	}
-}
-
-func getenv(key, fallback string) string {
-	if value, ok := os.LookupEnv(key); ok {
-		return value
-	}
-	return fallback
 }

--- a/policy/subpolicy/daily_schedule_subpolicy.go
+++ b/policy/subpolicy/daily_schedule_subpolicy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// OfficeHourSubPolicy is a subpolicy that extends the `SubPolicy` interface
+// DailyScheduleSubPolicy is a subpolicy that extends the `SubPolicy` interface
 // and takes in the GenericSubpolicy struct
 type DailyScheduleSubPolicy struct {
 	Name             string
@@ -26,7 +26,8 @@ func (sw ScalingWindow) IsInWindow(time int) bool {
 	return sw.Begin <= time && time < sw.End
 }
 
-// OfficeHourSubPolicyMetadata represents metadata unique to OfficeHourSubPolicy
+// DailyScheduleSubPolicyMetadata represents metadata unique to DailyScheduleSubPolicy
+// define windows of scaling through the day and a fallback default
 type DailyScheduleSubPolicyMetadata struct {
 	Default  *int            `json:"Default"`
 	Schedule []ScalingWindow `json:"Schedule"`
@@ -68,10 +69,11 @@ func (dssp *DailyScheduleSubPolicy) RecommendCount() map[resources.Resource]int 
 
 	output := make(map[resources.Resource]int)
 
-	// if within office hour, scale-up, else scale-down
 	for _, resc := range dssp.managedResources {
 		var recommendation int
 		windowExist := false
+
+		// uses count of the first window that current time falls into
 		for _, sw := range dssp.metadata.Schedule {
 			if sw.IsInWindow(currentTime) {
 				recommendation = sw.Count

--- a/policy/subpolicy/daily_schedule_subpolicy.go
+++ b/policy/subpolicy/daily_schedule_subpolicy.go
@@ -65,8 +65,14 @@ func (dssp DailyScheduleSubPolicy) GetManagedResources() []resources.Resource {
 }
 
 func (dssp *DailyScheduleSubPolicy) RecommendCount() map[resources.Resource]int {
-	loc, _ := time.LoadLocation(getenv("TZ", "Asia/Singapore"))
-	now := time.Now().In(loc)
+	loc, err := time.LoadLocation(getenv("TZ", "Asia/Singapore"))
+	var now time.Time
+	if err != nil {
+		now = time.Now().UTC().Add(8 * time.Hour)
+	} else {
+		now = time.Now().In(loc)
+	}
+
 	currentTime := (now.Hour())*100 + now.Minute()
 
 	output := make(map[resources.Resource]int)
@@ -108,9 +114,8 @@ func (dssp *DailyScheduleSubPolicy) DeriveGenericSubpolicy() GenericSubPolicy {
 }
 
 func getenv(key, fallback string) string {
-	value := os.Getenv(key)
-	if len(value) == 0 {
-		return fallback
+	if value, ok := os.LookupEnv(key); ok {
+		return value
 	}
-	return value
+	return fallback
 }

--- a/policy/subpolicy/daily_schedule_subpolicy_test.go
+++ b/policy/subpolicy/daily_schedule_subpolicy_test.go
@@ -23,9 +23,9 @@ func TestDecodingDailyScheduleSP(t *testing.T) {
 
 func TestWindowChecking(t *testing.T) {
 	sw := ScalingWindow{
-		begin: 0000,
-		end:   0200,
-		count: 10,
+		Begin: 0000,
+		Ed:    0200,
+		Count: 10,
 	}
 
 	if !sw.IsInWindow(0000) {

--- a/policy/subpolicy/daily_schedule_subpolicy_test.go
+++ b/policy/subpolicy/daily_schedule_subpolicy_test.go
@@ -1,0 +1,38 @@
+package subpolicy
+
+import (
+	"testing"
+
+	"github.com/datagovsg/nomad-parametric-autoscaler/resources"
+)
+
+func TestDecodingDailyScheduleSP(t *testing.T) {
+	input := map[string]interface{}{
+		"Default": 9.1,
+		"Schedule": []map[string]int{
+			{"Begin": 1, "End": 3, "Count": 3},
+			{"Begin": 3, "End": 4, "Count": 3},
+		},
+	}
+	emptyList := make([]resources.Resource, 0)
+	_, err := NewDailyScheduleSubPolicy("a", emptyList, input)
+	if err == nil {
+		t.Errorf("Expected typo for `UpThreshold` to be caught")
+	}
+}
+
+func TestWindowChecking(t *testing.T) {
+	sw := ScalingWindow{
+		begin: 0000,
+		end:   0200,
+		count: 10,
+	}
+
+	if !sw.IsInWindow(0000) {
+		t.Errorf("Expected 000hrs to be within window")
+	}
+
+	if sw.IsInWindow(0200) {
+		t.Errorf("Expected 0200hrs to be out of window")
+	}
+}

--- a/policy/subpolicy/office_hour_subpolicy.go
+++ b/policy/subpolicy/office_hour_subpolicy.go
@@ -2,9 +2,9 @@ package subpolicy
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/datagovsg/nomad-parametric-autoscaler/resources"
+	"github.com/datagovsg/nomad-parametric-autoscaler/utils"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -63,7 +63,7 @@ func (ohsp OfficeHourSubPolicy) GetManagedResources() []resources.Resource {
 }
 
 func (ohsp *OfficeHourSubPolicy) RecommendCount() map[resources.Resource]int {
-	currentHour := time.Now().UTC().Hour() + 8
+	currentHour := utils.GetCurrentTime().Hour()
 
 	output := make(map[resources.Resource]int)
 

--- a/policy/subpolicy/subpolicy.go
+++ b/policy/subpolicy/subpolicy.go
@@ -42,6 +42,12 @@ func CreateSpecificSubpolicy(gsp GenericSubPolicy, mr []resources.Resource) (Sub
 			return nil, err
 		}
 		return sp, nil
+	case types.DailySchedule:
+		sp, err := NewDailyScheduleSubPolicy(gsp.Name, mr, gsp.Metadata)
+		if err != nil {
+			return nil, err
+		}
+		return sp, nil
 	default:
 		return nil, fmt.Errorf("%v is not a valid subpolicy", gsp.Name)
 	}

--- a/types/constants.go
+++ b/types/constants.go
@@ -2,6 +2,7 @@ package types
 
 const CoreRatio = "CoreRatio"
 const OfficeHour = "OfficeHour"
+const DailySchedule = "DailySchedule"
 
 const ChangeTypeMultiply = "multiply"
 const ChangeTypeUntil = "until"
@@ -9,5 +10,5 @@ const ChangeTypeUntil = "until"
 const EnsembleConservative = "Conservative"
 const EnsembleAverage = "Average"
 
-var SubpolicyList = []string{CoreRatio, OfficeHour}
+var SubpolicyList = []string{CoreRatio, OfficeHour, DailySchedule}
 var EnsemblerList = []string{EnsembleConservative, EnsembleAverage}

--- a/utils/env.go
+++ b/utils/env.go
@@ -1,0 +1,10 @@
+package utils
+
+import "os"
+
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}

--- a/utils/time.go
+++ b/utils/time.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"time"
+)
+
+func GetCurrentTime() time.Time {
+	loc, err := time.LoadLocation(GetEnv("TZ", "Asia/Singapore"))
+	if err != nil {
+		return time.Now().UTC().Add(8 * time.Hour)
+	}
+	return time.Now().In(loc)
+}
+
+func GetCurrentTimeHHMM() int {
+	now := GetCurrentTime()
+	return (now.Hour())*100 + now.Minute()
+}


### PR DESCRIPTION
New sp allows user to set minimum levels throughout the day.

Daily Schedule's metadata schema.

```JSON
{
    "Default": 3,
    "Schedule": [
        { "Begin": 100, "End": 300, "Count": 10 },
        { "Begin": 800, "End": 1800, "Count": 20 }
    ]
}
```